### PR TITLE
Add ssl and basic auth support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ erl_crash.dump
 logs
 _build
 deps
+.elixir_ls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.6
-  - 1.7
+  - 1.8
+  - 1.9
 otp_release:
-  - 20.0
-  - 20.1
-  - 20.2
   - 20.3
+  - 21.2
 before_script:
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod +x rebar3

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2017 Ilya Khaprov <<i.khaprov@gmail.com>>.
 
-__Version:__ 0.0.1
+__Version:__ 0.1.0
 
 [![Hex.pm][Hex badge]][Hex link]
 [![Hex.pm Downloads][Hex downloads badge]][Hex link]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,18 @@ Mix config
 ```elixir
 config :prometheus,
     pushgateway: [
-        address: "localhost:9091"
+        address: "http://localhost:9091"
+    ]
+```
+
+If you require Basic Authentication to access the pushgateway add the following config keys:
+
+```elixir
+config :prometheus,
+    pushgateway: [
+        address: "http://localhost:9091",
+        auth_username: "<USERNAME>",
+        auth_password: "<PASSWORD>"
     ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Prometheus.Push.push(%{job: "qwe",
 Mix config
 
 ```elixir
-config: :prometheus,
+config :prometheus,
     pushgateway: [
         address: "localhost:9091"
     ]

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -101,6 +101,6 @@ MIT
 [Hex link]: https://hex.pm/packages/prometheus_push
 [Hex downloads badge]: https://img.shields.io/hexpm/dt/prometheus-push.svg?maxAge=2592000
 [Travis badge]: https://travis-ci.org/deadtrickster/prometheus-push.svg?branch=version-3
-[Travis link]: https://travis-ci.org/tonnenpinguin/prometheus-push.svg?branch=master
+[Travis link]: https://travis-ci.org/deadtrickster/prometheus-push
 [Coveralls badge]: https://coveralls.io/repos/github/deadtrickster/prometheus-push/badge.svg?branch=master
 [Coveralls link]: https://coveralls.io/github/deadtrickster/prometheus_push?branch=master

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,6 +1,6 @@
 @copyright 2017 Ilya Khaprov <<i.khaprov@gmail.com>>.
 @title Prometheus.io Pushgateway client.
-@version 0.0.1
+@version 0.1.0
 
 @doc
 
@@ -101,6 +101,6 @@ MIT
 [Hex link]: https://hex.pm/packages/prometheus_push
 [Hex downloads badge]: https://img.shields.io/hexpm/dt/prometheus-push.svg?maxAge=2592000
 [Travis badge]: https://travis-ci.org/deadtrickster/prometheus-push.svg?branch=version-3
-[Travis link]: https://travis-ci.org/deadtrickster/prometheus-push
+[Travis link]: https://travis-ci.org/tonnenpinguin/prometheus-push.svg?branch=master
 [Coveralls badge]: https://coveralls.io/repos/github/deadtrickster/prometheus-push/badge.svg?branch=master
 [Coveralls link]: https://coveralls.io/github/deadtrickster/prometheus_push?branch=master

--- a/elvis.config
+++ b/elvis.config
@@ -1,53 +1,53 @@
 [
  {
-   elvis,
-   [
-    {config,
-     [#{dirs => [
-                 "src"
+  elvis,
+  [
+   {config,
+    [#{dirs => [
+                "src"
+               ],
+       filter => "*.erl",
+       rules => [
+                 {elvis_style, line_length,
+                  #{limit => 80, skip_comments => false}},
+                 {elvis_style, invalid_dynamic_call,
+                  #{ignore => [
+                              ]}},
+                 {elvis_style, god_modules, #{limit => 25}}
                 ],
-        filter => "*.erl",
-        rules => [
-                  {elvis_style, line_length,
-                   #{limit => 80, skip_comments => false}},
-                  {elvis_style, invalid_dynamic_call,
-                   #{ignore => [
-                               ]}},
-                  {elvis_style, god_modules, #{limit => 25}}
-                 ],
-        ruleset => erl_files
-       },
-      #{dirs => [
-                 "test/eunit"
-                ],
-        filter => "*.erl",
-        rules => [
-                  {elvis_style, line_length,
-                   #{limit => 90}},
-                  {elvis_style, invalid_dynamic_call,
-                   #{ignore => [
-                               ]}},
-                  {elvis_style, god_modules, #{limit => 40}},
-                  %% looks like eunit generates underscored vars
-                  {elvis_style, variable_naming_convention, #{regex => "^([A-Z_][0-9a-zA-Z_]*)$"}},
+       ruleset => erl_files
+      },
+     #{dirs => [
+                "test/eunit"
+               ],
+       filter => "*.erl",
+       rules => [
+                 {elvis_style, line_length,
+                  #{limit => 90}},
+                 {elvis_style, invalid_dynamic_call,
+                  #{ignore => [
+                              ]}},
+                 {elvis_style, god_modules, #{limit => 40}},
+                 %% looks like eunit generates underscored vars
+                 {elvis_style, variable_naming_convention, #{regex => "^([A-Z_][0-9a-zA-Z_]*)$"}},
                   {elvis_style, dont_repeat_yourself, #{min_complexity => 200}}
-                 ],
-        ruleset => erl_files
-       },
-      #{dirs => ["."],
-        filter => "Makefile",
-        ruleset => makefiles
-       },
-      #{dirs => ["."],
-        filter => "rebar.config",
-        ruleset => rebar_config
-       },
-      #{dirs => ["."],
-        filter => "elvis.config",
-        ruleset => elvis_config
-       }
-     ]
-    }
-   ]
- }
-].
+                                                            ],
+                  ruleset => erl_files
+                 },
+                 #{dirs => ["."],
+                   filter => "Makefile",
+                   ruleset => makefiles
+                  },
+                 #{dirs => ["."],
+                   filter => "rebar.config",
+                   ruleset => rebar_config
+                  },
+                 #{dirs => ["."],
+                   filter => "elvis.config",
+                   ruleset => elvis_config
+                  }
+                ]
+      }
+    ]
+   }
+  ].

--- a/lib/prometheus/base.ex
+++ b/lib/prometheus/base.ex
@@ -1,0 +1,36 @@
+defmodule Prometheus.Base do
+  @moduledoc false
+
+  @callback push(Map.t()) ::
+              :ok
+              | {:error, {:missing_option, String.t()}}
+              | {:error, {:unknown_registry, String.t()}}
+              | {:error, {:to_string_failed, String.t()}}
+  @callback push(String.t()) ::
+              :ok
+              | {:error, {:missing_option, String.t()}}
+              | {:error, {:unknown_registry, String.t()}}
+              | {:error, {:to_string_failed, String.t()}}
+
+  @callback add(Map.t()) ::
+              :ok
+              | {:error, {:missing_option, String.t()}}
+              | {:error, {:unknown_registry, String.t()}}
+              | {:error, {:to_string_failed, String.t()}}
+  @callback add(String.t()) ::
+              :ok
+              | {:error, {:missing_option, String.t()}}
+              | {:error, {:unknown_registry, String.t()}}
+              | {:error, {:to_string_failed, String.t()}}
+
+  @callback delete(Map.t()) ::
+              :ok
+              | {:error, {:missing_option, String.t()}}
+              | {:error, {:unknown_registry, String.t()}}
+              | {:error, {:to_string_failed, String.t()}}
+  @callback delete(String.t()) ::
+              :ok
+              | {:error, {:missing_option, String.t()}}
+              | {:error, {:unknown_registry, String.t()}}
+              | {:error, {:to_string_failed, String.t()}}
+end

--- a/lib/prometheus/push.ex
+++ b/lib/prometheus/push.ex
@@ -1,4 +1,5 @@
 defmodule Prometheus.Push do
+  @behaviour Prometheus.Base
 
   @moduledoc """
     Prometheus.Push works with the [prometheus.ex](https://github.com/deadtrickster/prometheus.ex/) library to push metrics to a [Pushgateway](https://github.com/prometheus/pushgateway).
@@ -16,14 +17,17 @@ defmodule Prometheus.Push do
                        grouping_key: [{"abra", "kadabra"}]})
 
   """
+  @impl Prometheus.Base
   def push(options) do
     :prometheus_push.push(options)
   end
 
+  @impl Prometheus.Base
   def add(options) do
     :prometheus_push.add(options)
   end
 
+  @impl Prometheus.Base
   def delete(options) do
     :prometheus_push.delete(options)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,29 +1,32 @@
 defmodule PrometheusPush.Mixfile do
   use Mix.Project
 
-  @version "0.0.1"
+  @version "0.1.0"
 
   def project do
-    [app: :prometheus_push,
-     version: @version,
-     elixir: "~> 1.3",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     name: "Prometheus Push",
-     deps: deps(),
-     test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: ["coveralls": :test, "coveralls.html": :test],
-     docs: [main: Prometheus,
-            source_ref: "v#{@version}",
-            source_url: "https://github.com/deadtrickster/prometheus-push",
-            extras: []]]
+    [
+      app: :prometheus_push,
+      version: @version,
+      elixir: "~> 1.3",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      name: "Prometheus Push",
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [coveralls: :test, "coveralls.html": :test],
+      docs: [
+        main: Prometheus,
+        source_ref: "v#{@version}",
+        source_url: "https://github.com/deadtrickster/prometheus-push",
+        extras: []
+      ]
+    ]
   end
 
   def application do
-    [applications: [:logger,
-                    :prometheus_ex]]
+    [applications: [:logger, :prometheus_ex]]
   end
 
   defp description do
@@ -33,24 +36,28 @@ defmodule PrometheusPush.Mixfile do
   end
 
   defp package do
-    [maintainers: ["Ilya Khaprov"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/deadtrickster/prometheus-push",
-              "Prometheus.erl" => "https://hex.pm/packages/prometheus",
-              "Prometheus.ex" => "https://hex.pm/packages/prometheus_ex",
-              "Inets HTTPD Exporter" => "https://hex.pm/packages/prometheus_httpd",
-              "Ecto Instrumenter" => "https://hex.pm/packages/prometheus_ecto",
-              "Phoenix Instrumenter" => "https://hex.pm/packages/prometheus_phoenix",
-              "Plugs Instrumenter/Exporter" => "https://hex.pm/packages/prometheus_plugs",
-              "Process info Collector" => "https://hex.pm/packages/prometheus_process_collector"}]
+    [
+      maintainers: ["Ilya Khaprov"],
+      licenses: ["MIT"],
+      links: %{
+        "GitHub" => "https://github.com/deadtrickster/prometheus-push",
+        "Prometheus.erl" => "https://hex.pm/packages/prometheus",
+        "Prometheus.ex" => "https://hex.pm/packages/prometheus_ex",
+        "Inets HTTPD Exporter" => "https://hex.pm/packages/prometheus_httpd",
+        "Ecto Instrumenter" => "https://hex.pm/packages/prometheus_ecto",
+        "Phoenix Instrumenter" => "https://hex.pm/packages/prometheus_phoenix",
+        "Plugs Instrumenter/Exporter" => "https://hex.pm/packages/prometheus_plugs",
+        "Process info Collector" => "https://hex.pm/packages/prometheus_process_collector"
+      }
+    ]
   end
 
   defp deps do
-    [{:prometheus_ex, "~> 3.0"},
-
-     {:credo, "~> 0.10.0", only: [:dev, :test], runtime: false},
-
-     {:ex_doc, "~> 0.15", only: :dev},
-     {:earmark, ">= 0.0.0", only: :dev}]
+    [
+      {:prometheus_ex, "~> 3.0"},
+      {:credo, "~> 1.1.0", only: [:dev, :test], runtime: false},
+      {:ex_doc, "~> 0.15", only: :dev},
+      {:earmark, ">= 0.0.0", only: :dev}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule PrometheusPush.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :prometheus_ex]]
+    [applications: [:logger, :prometheus_ex], extra_applications: [:inets, :ssl]]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,12 @@
 %{
-  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
-  "credo": {:hex, :credo, "0.10.2", "03ad3a1eff79a16664ed42fc2975b5e5d0ce243d69318060c626c34720a49512", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "1.1.0", "e0c07b2fd7e2109495f582430a1bc96b2c71b7d94c59dfad120529f65f19872f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "prometheus": {:hex, :prometheus, "4.2.0", "06c58bfdfe28d3168b926da614cb9a6d39593deebde648a5480e32dfa3c370e9", [:mix, :rebar3], [], "hexpm"},
-  "prometheus_ex": {:hex, :prometheus_ex, "3.0.3", "5d722263bb1f7a9b1d02554de42e61ea672b4e3c07c3f74e23ce35ab5e111cfa", [:mix], [{:prometheus, "~> 4.0", [hex: :prometheus, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "prometheus": {:hex, :prometheus, "4.4.0", "6dcb11fc80faf873cb2297664720414aed16b0a4fc3a1a15ae538d66f84ccc34", [:mix, :rebar3], [], "hexpm"},
+  "prometheus_ex": {:hex, :prometheus_ex, "3.0.5", "fa58cfd983487fc5ead331e9a3e0aa622c67232b3ec71710ced122c4c453a02f", [:mix], [{:prometheus, "~> 4.0", [hex: :prometheus, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,12 +1,12 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "1.1.0", "e0c07b2fd7e2109495f582430a1bc96b2c71b7d94c59dfad120529f65f19872f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "1.1.2", "02b6422f3e659eb74b05aca3c20c1d8da0119a05ee82577a82e6c2938bf29f81", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.3", "5e8be428fcef362692b6dbd7dc55bdc7023da26d995cb3fb19aa4bd682bfd3f9", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.1", "5ac36660846967cd869255f4426467a11672fec3d8db602c429425ce5b613b90", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
-  "prometheus": {:hex, :prometheus, "4.4.0", "6dcb11fc80faf873cb2297664720414aed16b0a4fc3a1a15ae538d66f84ccc34", [:mix, :rebar3], [], "hexpm"},
+  "prometheus": {:hex, :prometheus, "4.4.1", "1e96073b3ed7788053768fea779cbc896ddc3bdd9ba60687f2ad50b252ac87d6", [:mix, :rebar3], [], "hexpm"},
   "prometheus_ex": {:hex, :prometheus_ex, "3.0.5", "fa58cfd983487fc5ead331e9a3e0aa622c67232b3ec71710ced122c4c453a02f", [:mix], [{:prometheus, "~> 4.0", [hex: :prometheus, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {erl_opts, [debug_info]}.
-{plugins, [{coveralls, "1.3.0"},
-           {rebar3_lint, "0.1.7"}]}.
+{plugins, [{coveralls, "2.0.1"},
+           {rebar3_lint, "0.1.10"}]}.
 
 {post_hooks, []}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
 %% -*- mode: erlang -*-
 {erl_opts, [debug_info]}.
 {plugins, [{coveralls, "2.0.1"},
-           {rebar3_lint, "0.1.10"}]}.
+           {rebar3_lint, "0.1.10"}, 
+           rebar3_fmt]}.
 
 {post_hooks, []}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {post_hooks, []}.
 
-{deps, [{prometheus, "3.2.2"}]}.
+{deps, [{prometheus, "4.4.0"}]}.
 {shell, [{apps, [prometheus_push]}]}.
 {cover_enabled, true}.
 {cover_export_enabled, true}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,7 @@
 case os:getenv("TRAVIS") of
-  "true" ->
-    JobId   = os:getenv("TRAVIS_JOB_ID"),
-    lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId});
-  _ ->
-    CONFIG
+    "true" ->
+        JobId   = os:getenv("TRAVIS_JOB_ID"),
+        lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId});
+    _ ->
+        CONFIG
 end.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 {"1.1.0",
-[{<<"prometheus">>,{pkg,<<"prometheus">>,<<"3.2.2">>},0}]}.
+[{<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.4.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"prometheus">>, <<"887A687855E171852BE3E023AEA9DBC1EA3CE0F327B95765896EBB2847FEF7F9">>}]}
+ {<<"prometheus">>, <<"6DCB11FC80FAF873CB2297664720414AED16B0A4FC3A1A15AE538D66F84CCC34">>}]}
 ].

--- a/src/prometheus_push.erl
+++ b/src/prometheus_push.erl
@@ -1,163 +1,154 @@
 -module(prometheus_push).
 
--export([push/0,
-         push/1,
-
-         add/0,
-         add/1,
-
-         delete/0,
-         delete/1
-        ]).
+-export([add/0, add/1, delete/0, delete/1, push/0,
+         push/1]).
 
 -export([hostname_grouping_key/0]).
 
 -ifdef(TEST).
--export([encode_grouping_key/1,
-         to_string/1,
-         get_config_from_env/0,
-         prepare_request_params/1,
-         construct_url/3]).
+
+-export([construct_url/3, encode_grouping_key/1,
+         get_config_from_env/0, prepare_request_params/1,
+         to_string/1]).
+
 -endif.
 
 %%%===================================================================
 %%% API
 %%%===================================================================
 
-push() ->
-  request(put, #{}).
+push() -> request(put, #{}).
 
 push(Options) when is_map(Options) ->
-  request(put, Options);
-push(Job) ->
-  request(put, #{job => Job}).
+    request(put, Options);
+push(Job) -> request(put, #{job => Job}).
 
-add() ->
-  request(post, #{}).
+add() -> request(post, #{}).
 
 add(Options) when is_map(Options) ->
-  request(post, Options);
-add(Job) ->
-  request(post, #{job => Job}).
+    request(post, Options);
+add(Job) -> request(post, #{job => Job}).
 
-delete() ->
-  request(delete, #{}).
+delete() -> request(delete, #{}).
 
 delete(Options) when is_map(Options) ->
-  request(delete, Options);
-delete(Job) ->
-  request(delete, #{job => Job}).
+    request(delete, Options);
+delete(Job) -> request(delete, #{job => Job}).
 
 hostname_grouping_key() ->
-  {ok, Hostname} = inet:gethostname(),
-  #{
-     <<"instance">> => Hostname
-   }.
+    {ok, Hostname} = inet:gethostname(),
+    #{<<"instance">> => Hostname}.
 
 %%%===================================================================
 %%% Private functions
 %%%===================================================================
 
 request(Method, Request) ->
-  try
-    {Job, Registry, GroupingKey, Address} = prepare_request_params(Request),
+    try {Job, Registry, GroupingKey, Address, Headers} =
+             prepare_request_params(Request),
+         URL = construct_url(Address, Job, GroupingKey),
+         ContentType = prometheus_text_format:content_type(),
+         HTTPOptions = get_http_options(URL),
+         Body = case Method of
+                    delete -> <<>>;
+                    _ -> prometheus_text_format:format(Registry)
+                end,
+         request(Method, URL, Headers, ContentType, Body,
+                 HTTPOptions)
+    catch
+        error:{badkey, Key} -> {error, {missing_option, Key}};
+        error:{unknown_registry, UR} ->
+            {error, {unknown_registry, UR}};
+        error:{to_string_failed, IS} ->
+            {error, {to_string_failed, IS}}
+    end.
 
-    URL = construct_url(Address, Job, GroupingKey),
-
-    ContentType = prometheus_text_format:content_type(),
-
-    Body =
-      case Method of
-        delete ->
-          <<>>;
-        _ ->
-          prometheus_text_format:format(Registry)
-      end,
-
-    request(Method, URL, ContentType, Body)
-
-  catch
-    error:{badkey, Key} ->
-      {error, {missing_option, Key}};
-    error:{unknown_registry, UR} ->
-      {error, {unknown_registry, UR}};
-    error:{to_string_failed, IS} ->
-      {error, {to_string_failed, IS}}
-  end.
-
-request(Method, URL0, CT0, Body) ->
-  URL = binary_to_list(iolist_to_binary(URL0)),
-  CT = binary_to_list(iolist_to_binary(CT0)),
-
-  case httpc:request(Method, {URL, [], CT, Body}, [], []) of
-    {ok, {{_, 202, _}, _, _}} ->
-      ok;
-    Error -> Error
-  end.
+request(Method, URL0, Headers, ContentType0, Body,
+        HTTPOptions) ->
+    URL = binary_to_list(iolist_to_binary(URL0)),
+    ContentType =
+        binary_to_list(iolist_to_binary(ContentType0)),
+    case httpc:request(Method,
+                       {URL, Headers, ContentType, Body}, HTTPOptions, [])
+    of
+        {ok, {{_, 202, _}, _, _}} -> ok;
+        Error -> Error
+    end.
 
 prepare_request_params(Request) ->
-  Config0 = get_config_from_env(),
+    Config0 = get_config_from_env(),
+    Config = maps:merge(Config0, Request),
+    Job = maps:get(job, Config),
+    Registry = maps:get(registry, Config, default),
+    case prometheus_registry:exists(Registry) of
+        true -> ok;
+        false -> erlang:error({unknown_registry, Registry})
+    end,
+    GroupingKey = maps:get(grouping_key, Config, #{}),
+    Address = maps:get(address, Config,
+                       "http://127.0.0.1:9091"),
+    Headers = get_auth_headers(Config),
+    {Job, Registry, GroupingKey, Address, Headers}.
 
-  Config = maps:merge(Config0, Request),
+get_http_options([URL0 | _Tail]) ->
+    URL = to_string(URL0),
+    case lists:prefix("https://", URL) of
+        true ->
+            [{ssl, [{versions, ['tlsv1.2']}]}];
+        _ ->
+            []
+    end.
 
-  Job = maps:get(job, Config),
-
-  Registry = maps:get(registry, Config, default),
-  case prometheus_registry:exists(Registry) of
-    true -> ok;
-    false ->
-      erlang:error({unknown_registry, Registry})
-  end,
-
-  GroupingKey = maps:get(grouping_key, Config, #{}),
-
-  Address = maps:get(address, Config, "http://127.0.0.1:9091"),
-
-  {Job, Registry, GroupingKey, Address}.
+get_auth_headers(#{auth_username := UserName0,
+                   auth_password := UserPassword0}) ->
+    UserName = to_string(UserName0),
+    UserPassword = to_string(UserPassword0),
+    AuthStr = base64:encode_to_string(UserName ++
+                                          ":" ++ UserPassword),
+    Headers = [{"Authorization", "Basic " ++ AuthStr}],
+    Headers;
+get_auth_headers(_Config) -> [].
 
 get_config_from_env() ->
-  case application:get_env(prometheus, pushgateway, #{}) of
-    LC when is_list(LC) ->
-      MC = maps:from_list(LC),
-      application:set_env(prometheus, pushgateway, MC),
-      MC;
-    MC when is_map(MC) ->
-      MC
-  end.
+    case application:get_env(prometheus, pushgateway, #{})
+    of
+        ListConfig when is_list(ListConfig) ->
+            MapConfig = maps:from_list(ListConfig),
+            application:set_env(prometheus, pushgateway, MapConfig),
+            MapConfig;
+        MapConfig when is_map(MapConfig) -> MapConfig
+    end.
 
 encode_grouping_key(GK) when is_map(GK) ->
-  maps:fold(fun(K, V, Acc) ->
-                [encode_grouping_key_pair(K, V) ++ Acc]
-            end,
-            [],
-            GK);
-encode_grouping_key(GK) when is_list(GK) ->
-  lists:foldl(fun({K, V}, Acc) ->
-                  [encode_grouping_key_pair(K, V) ++ Acc]
+    maps:fold(fun (K, V, Acc) ->
+                      [encode_grouping_key_pair(K, V) ++ Acc]
               end,
-              [],
-              GK).
+              [], GK);
+encode_grouping_key(GK) when is_list(GK) ->
+    lists:foldl(fun ({K, V}, Acc) ->
+                        [encode_grouping_key_pair(K, V) ++ Acc]
+                end,
+                [], GK).
 
 encode_grouping_key_pair(K, V) ->
-  ["/", http_uri:encode(to_string(K)),
-   "/", http_uri:encode(to_string(V))].
+    ["/", http_uri:encode(to_string(K)), "/",
+     http_uri:encode(to_string(V))].
 
 to_string(Val) ->
-  binary_to_list(iolist_to_binary(to_string_(Val))).
+    binary_to_list(iolist_to_binary(to_string_(Val))).
 
 to_string_(Val) when is_atom(Val) ->
-  atom_to_binary(Val, utf8);
+    atom_to_binary(Val, utf8);
 to_string_(Val) when is_number(Val) ->
-  io_lib:format("~p", [Val]);
+    io_lib:format("~p", [Val]);
 to_string_(Val) ->
-  try iolist_to_binary(Val) of
-      Str -> Str
-  catch
-    error:badarg ->
-      erlang:error({to_string_failed, Val})
-  end.
+    try iolist_to_binary(Val) of
+        Str -> Str
+    catch
+        error:badarg -> erlang:error({to_string_failed, Val})
+    end.
 
 construct_url(Address, Job, GroupingKey) ->
-  [Address,
-   "/metrics/job/", http_uri:encode(to_string(Job)),
-   encode_grouping_key(GroupingKey)].
+    [Address, "/metrics/job/",
+     http_uri:encode(to_string(Job)),
+     encode_grouping_key(GroupingKey)].

--- a/test/eunit/prometheus_push_tests.erl
+++ b/test/eunit/prometheus_push_tests.erl
@@ -5,148 +5,181 @@
 -define(CT, "text/plain; version=0.0.4").
 
 to_string_test() ->
-  ?assertMatch("qwe", prometheus_push:to_string(qwe)),
-  ?assertMatch("qwe", prometheus_push:to_string(<<"qwe">>)),
-  ?assertMatch("qwe", prometheus_push:to_string("qwe")),
-  ?assertMatch("44.2", prometheus_push:to_string(44.2)),
-
-  ?assertMatch({'EXIT',
-                {{to_string_failed, #{}}, _}},
-               catch prometheus_push:to_string(#{})).
+    ?assertMatch("qwe", (prometheus_push:to_string(qwe))),
+    ?assertMatch("qwe",
+                 (prometheus_push:to_string(<<"qwe">>))),
+    ?assertMatch("qwe", (prometheus_push:to_string("qwe"))),
+    ?assertMatch("44.2",
+                 (prometheus_push:to_string(4.42e+1))),
+    ?assertMatch({'EXIT', {{to_string_failed, #{}}, _}},
+                 (catch prometheus_push:to_string(#{}))).
 
 encode_grouping_key_test() ->
-  ?assertMatch(<<"/qwe%2Fqwe/qwe%2Fqwe">>,
-               iolist_to_binary(
-                 prometheus_push:encode_grouping_key(#{"qwe/qwe" => "qwe/qwe"}))),
-
-  ?assertMatch(<<"/qwe%2Fqwe/qwe%2Fqwe">>,
-               iolist_to_binary(
-                 prometheus_push:encode_grouping_key([{"qwe/qwe", "qwe/qwe"}]))).
+    ExpectedKey = <<"/qwe%2Fqwe/qwe%2Fqwe">>,
+    EncodedMap = prometheus_push:encode_grouping_key(#{"qwe/qwe" => "qwe/qwe"}),
+    EncodedList = prometheus_push:encode_grouping_key([{"qwe/qwe", "qwe/qwe"}]),
+    ?assertMatch(ExpectedKey, (iolist_to_binary(EncodedMap))),
+    ?assertMatch(ExpectedKey, (iolist_to_binary(EncodedList))).
 
 get_config_from_env_test() ->
-  try
-    begin
-      ?assertMatch(Map when map_size(Map) == 0,
-                            prometheus_push:get_config_from_env()),
+    try begin
+            ?assertMatch(Map when map_size(Map) == 0,
+                                  prometheus_push:get_config_from_env()),
+            application:set_env(prometheus, pushgateway, #{ "qwe" => "qwe" }),
+            ?assertMatch(#{ "qwe" := "qwe" },
+                         prometheus_push:get_config_from_env()),
+            application:set_env(prometheus, pushgateway, [{"qwe" , "qwe"}]),
+            ?assertMatch(#{ "qwe" := "qwe" },
+                         prometheus_push:get_config_from_env()) ,
+            ?assertMatch({ ok , # { "qwe" := "qwe" } },
+                         application:get_env(prometheus , pushgateway) )
+        end after
+                application:set_env(prometheus , pushgateway , #{ } )
+            end.
 
-
-      application:set_env(prometheus, pushgateway, #{"qwe" => "qwe"}),
-      ?assertMatch(#{"qwe" := "qwe"},
-                   prometheus_push:get_config_from_env()),
-
-      application:set_env(prometheus, pushgateway, [{"qwe", "qwe"}]),
-      ?assertMatch(#{"qwe" := "qwe"},
-                   prometheus_push:get_config_from_env()),
-      ?assertMatch({ok, #{"qwe" := "qwe"}}, application:get_env(prometheus, pushgateway))
-    end
-  after
-    application:set_env(prometheus, pushgateway, #{})
-  end.
 
 prepare_request_params_test() ->
-  try
-    begin
-      prometheus:start(),
-      ?assertMatch({'EXIT',
-                    {{badkey, job}, _}},
-                   catch prometheus_push:prepare_request_params(#{})),
-      ?assertMatch({'EXIT',
-                    {{unknown_registry, qwe}, _}},
-                   catch prometheus_push:prepare_request_params(#{job => "qwe",
-                                                                  registry => qwe})),
-
-
-      ?assertMatch({"qwe", default, #{}, "http://127.0.0.1:9091"},
-                   prometheus_push:prepare_request_params(#{job => "qwe"})),
-
-      application:set_env(prometheus, pushgateway, [{job, "qwe"}]),
-      ?assertMatch({"qwe", default, #{}, "http://127.0.0.1:9091"},
-                   prometheus_push:prepare_request_params(#{})),
-
-      application:set_env(prometheus, pushgateway, [{job, "qwe"},
-                                                    {registry, qwe}]),
-      ?assertMatch({"qwe", default, #{}, "http://127.0.0.1:9091"},
-                   prometheus_push:prepare_request_params(#{registry => default}))
-    end
-  after
-    application:set_env(prometheus, pushgateway, #{})
-  end.
+    try begin
+            prometheus:start(),
+            ?assertMatch({'EXIT', {{badkey, job}, _}},
+                         (catch prometheus_push:prepare_request_params(#{}))),
+            ?assertMatch({'EXIT', {{unknown_registry, qwe}, _}},
+                         (catch prometheus_push:prepare_request_params(#{job =>
+                                                                             "qwe",
+                                                                         registry
+                                                                         =>
+                                                                             qwe}))),
+            ?assertMatch({"qwe", default, #{},
+                          "http://127.0.0.1:9091", []},
+                         (prometheus_push:prepare_request_params(#{job =>
+                                                                       "qwe"}))),
+            application:set_env(prometheus, pushgateway,
+                                [{job, "qwe"}]),
+            ?assertMatch({"qwe", default, #{},
+                          "http://127.0.0.1:9091", []},
+                         (prometheus_push:prepare_request_params(#{}))),
+            application:set_env(prometheus, pushgateway,
+                                [{job, "qwe"}, {registry, qwe}]),
+            ?assertMatch({"qwe", default, #{},
+                          "http://127.0.0.1:9091", []},
+                         (prometheus_push:prepare_request_params(#{registry =>
+                                                                       default}))),
+            application:set_env(prometheus, pushgateway,
+                                [{job, "qwe"}, {auth_username, "test"},
+                                 {auth_password, "pass"}]),
+            ?assertMatch({"qwe", default, #{},
+                          "http://127.0.0.1:9091",
+                          [{"Authorization", "Basic dGVzdDpwYXNz"}]},
+                         (prometheus_push:prepare_request_params(#{})))
+        end
+    after
+        application:set_env(prometheus, pushgateway, #{})
+    end.
 
 construct_url_test() ->
-  ?assertMatch(["address", "/metrics/job/", "qwe%2Fqwe",
-                [["/", "qwe%2Fqwe", "/", "qwe%2Fqwe"]]],
-               prometheus_push:construct_url("address", "qwe/qwe",
-                                             #{"qwe/qwe" => "qwe/qwe"})).
+    ?assertMatch(["address", "/metrics/job/", "qwe%2Fqwe",
+                  [["/", "qwe%2Fqwe", "/", "qwe%2Fqwe"]]],
+                 (prometheus_push:construct_url("address", "qwe/qwe",
+                                                #{"qwe/qwe" => "qwe/qwe"}))).
 
 operations_test_() ->
-  {foreach,
-   fun() ->
-       meck:new(httpc)
-   end,
-   fun(_) ->
-       meck:unload(httpc)
-   end,
-   [
-    fun() ->
-        meck:expect(httpc, request,
-                    fun(put,
-                        {"http://127.0.0.1:9091/metrics/job/qwe", [], ?CT, Body}, [], [])
-                        when size(Body) > 0 ->
-                        {ok, {{"HTTP/1.1", 202, "Accepted"},
-                              [{"date", "Sat, 18 Mar 2017 07:59:36 GMT"},
-                               {"content-length", "0"},
-                               {"content-type", "text/plain; charset=utf-8"}],
-                              []}}
-                    end),
-
-        ?assertEqual(ok, prometheus_push:push(#{job => "qwe"})),
-        ?assert(meck:validate(httpc))
-    end,
-    fun() ->
-        meck:expect(httpc, request,
-                    fun(put,
-                        {"http://127.0.0.1:9091/metrics/job/qwe/qwe/qwe",
-                         [], ?CT, Body}, [], [])
-                        when size(Body) > 0 ->
-                        {ok, {{"HTTP/1.1", 202, "Accepted"},
-                              [{"date", "Sat, 18 Mar 2017 07:59:36 GMT"},
-                               {"content-length", "0"},
-                               {"content-type", "text/plain; charset=utf-8"}],
-                              []}}
-                    end),
-
-        ?assertEqual(ok, prometheus_push:push(#{job => "qwe",
-                                                grouping_key => #{"qwe" => "qwe"}})),
-        ?assert(meck:validate(httpc))
-    end,
-    fun() ->
-        meck:expect(httpc, request,
-                    fun(post,
-                        {"http://127.0.0.1:9091/metrics/job/qwe", [], ?CT, Body}, [], [])
-                        when size(Body) > 0 ->
-                        {ok, {{"HTTP/1.1", 202, "Accepted"},
-                              [{"date", "Sat, 18 Mar 2017 07:59:36 GMT"},
-                               {"content-length", "0"},
-                               {"content-type", "text/plain; charset=utf-8"}],
-                              []}}
-                    end),
-
-        ?assertEqual(ok, prometheus_push:add("qwe")),
-        ?assert(meck:validate(httpc))
-    end,
-    fun() ->
-        meck:expect(httpc, request,
-                    fun(delete,
-                        {"http://127.0.0.1:9091/metrics/job/qwe", [], ?CT, <<>>}, [], [])
-                       ->
-                        {ok, {{"HTTP/1.1", 202, "Accepted"},
-                              [{"date", "Sat, 18 Mar 2017 07:59:36 GMT"},
-                               {"content-length", "0"},
-                               {"content-type", "text/plain; charset=utf-8"}],
-                              []}}
-                    end),
-
-        ?assertEqual(ok, prometheus_push:delete("qwe")),
-        ?assert(meck:validate(httpc))
-    end
-   ]}.
+    {foreach, fun () -> meck:new(httpc) end,
+     fun (_) -> meck:unload(httpc) end,
+     [fun () ->
+              meck:expect(httpc, request,
+                          fun (put,
+                               {"http://127.0.0.1:9091/metrics/job/qwe", [],
+                                ?CT, Body},
+                               [], [])
+                                when size(Body) > 0 ->
+                                  {ok,
+                                   {{"HTTP/1.1", 202, "Accepted"},
+                                    [{"date", "Sat, 18 Mar 2017 07:59:36 GMT"},
+                                     {"content-length", "0"},
+                                     {"content-type",
+                                      "text/plain; charset=utf-8"}],
+                                    []}}
+                          end),
+              ?assertEqual(ok,
+                           (prometheus_push:push(#{job => "qwe"}))),
+              ?assert((meck:validate(httpc)))
+      end,
+      fun () ->
+              meck:expect(httpc, request,
+                          fun (put,
+                               {"http://127.0.0.1:9091/metrics/job/qwe/qwe/qwe",
+                                [], ?CT, Body},
+                               [], [])
+                                when size(Body) > 0 ->
+                                  {ok,
+                                   {{"HTTP/1.1", 202, "Accepted"},
+                                    [{"date", "Sat, 18 Mar 2017 07:59:36 GMT"},
+                                     {"content-length", "0"},
+                                     {"content-type",
+                                      "text/plain; charset=utf-8"}],
+                                    []}}
+                          end),
+              ?assertEqual(ok,
+                           (prometheus_push:push(#{job => "qwe",
+                                                   grouping_key =>
+                                                       #{"qwe" => "qwe"}}))),
+              ?assert((meck:validate(httpc)))
+      end,
+      fun () ->
+              meck:expect(httpc, request,
+                          fun (post,
+                               {"http://127.0.0.1:9091/metrics/job/qwe", [],
+                                ?CT, Body},
+                               [], [])
+                                when size(Body) > 0 ->
+                                  {ok,
+                                   {{"HTTP/1.1", 202, "Accepted"},
+                                    [{"date", "Sat, 18 Mar 2017 07:59:36 GMT"},
+                                     {"content-length", "0"},
+                                     {"content-type",
+                                      "text/plain; charset=utf-8"}],
+                                    []}}
+                          end),
+              ?assertEqual(ok, (prometheus_push:add("qwe"))),
+              ?assert((meck:validate(httpc)))
+      end,
+      fun () ->
+              meck:expect(httpc, request,
+                          fun (delete,
+                               {"http://127.0.0.1:9091/metrics/job/qwe", [],
+                                ?CT, <<>>},
+                               [], []) ->
+                                  {ok,
+                                   {{"HTTP/1.1", 202, "Accepted"},
+                                    [{"date", "Sat, 18 Mar 2017 07:59:36 GMT"},
+                                     {"content-length", "0"},
+                                     {"content-type",
+                                      "text/plain; charset=utf-8"}],
+                                    []}}
+                          end),
+              ?assertEqual(ok, (prometheus_push:delete("qwe"))),
+              ?assert((meck:validate(httpc)))
+      end,
+      fun () ->
+              meck:expect(httpc, request,
+                          fun (put,
+                               {"https://ssltest.com/metrics/job/qwe", [], ?CT,
+                                Body},
+                               HTTPOpts, [])
+                                when size(Body) > 0 ->
+                                  ExpectedHTTPOpts = [{ssl, [{versions, ['tlsv1.2']}]}],
+                                  ?assertEqual(ExpectedHTTPOpts, HTTPOpts),
+                                  {ok,
+                                   {{"HTTP/1.1", 202, "Accepted"},
+                                    [{"date", "Sat, 18 Mar 2017 07:59:36 GMT"},
+                                     {"content-length", "0"},
+                                     {"content-type",
+                                      "text/plain; charset=utf-8"}],
+                                    []}}
+                          end),
+              application:set_env(prometheus, pushgateway,
+                                  [{address, "https://ssltest.com"}]),
+              ?assertEqual(ok,
+                           (prometheus_push:push(#{job => "qwe"}))),
+              ?assert((meck:validate(httpc)))
+      end]}.


### PR DESCRIPTION
This MR implements ssl support (HTTP Options are only added when the address starts with `https://`) and basic authorization support.

The Basic Authentication Headers are added when the `auth_username` and `auth_password` config keys are added.

I've also added fmt as a plugin (run using `rebar3 fmt`) to make formatting a bit more consistent and updated all dependencies to a recent version.